### PR TITLE
Captured CMD-S event

### DIFF
--- a/index.php
+++ b/index.php
@@ -312,6 +312,17 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
 				}
 			}
 		});
+		jQuery(window).bind('keydown', function(event) {
+    			if (event.ctrlKey || event.metaKey) {
+        			switch (String.fromCharCode(event.which).toLowerCase()) {
+        				case 's':
+            				event.preventDefault();
+            				var SaveForm = jQuery("button.btn.btn-small.btn-success").attr("onclick");
+            				eval(SaveForm);
+            				break;
+        			}
+    			}
+		});
 	</script>
 <?php endif; ?>
 </body>

--- a/index.php
+++ b/index.php
@@ -317,7 +317,7 @@ $stickyToolbar = $this->params->get('stickyToolbar', '1');
         			switch (String.fromCharCode(event.which).toLowerCase()) {
         				case 's':
             				event.preventDefault();
-            				var SaveForm = jQuery("button.btn.btn-small.btn-success").attr("onclick");
+            				var SaveForm = jQuery("#toolbar-apply button").attr("onclick");
             				eval(SaveForm);
             				break;
         			}


### PR DESCRIPTION
I got tired of accidentally pressing CMD-S when trying to save something in Joomla. This little bit of code will capture the CMD-S (or CTRL-S) and save the form (not the browser page) any time you're editing an entity (module, article, menu item, etc...). It tested and it works on Mac and Windows on all major browsers. Keep it if you like it; otherwise, you won't hurt my feelings.
